### PR TITLE
TranslateOffset is updated OnTranslateChanged

### DIFF
--- a/RichCanvas/RichItemsControl.cs
+++ b/RichCanvas/RichItemsControl.cs
@@ -720,6 +720,7 @@ namespace RichCanvas
 
         private void OnTranslateChanged(object sender, EventArgs e)
         {
+            TranslateOffset = new Point(TranslateTransform.X, TranslateTransform.Y);
             RaiseScrollingEvent(e);
         }
 

--- a/RichCanvasDemo/Common/ViewPresetItem.cs
+++ b/RichCanvasDemo/Common/ViewPresetItem.cs
@@ -1,0 +1,13 @@
+﻿using System.Windows;
+
+namespace RichCanvasDemo.Common
+{
+    public class ViewPresetItem
+    { 
+        public string Name { get; set; }
+
+        public Point Offset { get; set; }
+
+        public string Scale { get; set; }
+    }
+}

--- a/RichCanvasDemo/MainWindow.xaml
+++ b/RichCanvasDemo/MainWindow.xaml
@@ -14,7 +14,7 @@
         mc:Ignorable="d"
         x:Name="window"
         Title="MainWindow"
-        Height="650"
+        Height="800"
         WindowState="Maximized"
         Width="800">
     <Window.InputBindings>
@@ -68,6 +68,7 @@
         <!--INFORMATIONS PROPS API-->
         <Grid Grid.Row="1">
             <Grid.RowDefinitions>
+                <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
@@ -163,7 +164,7 @@
                          md:HintAssist.IsFloating="True" />
             </StackPanel>
 
-            <StackPanel Grid.Row="10">
+            <StackPanel Grid.Row="7">
                 <TextBox Text="{Binding ElementsCount, Mode=TwoWay}"
                          md:HintAssist.Hint="Number of elements"
                          md:HintAssist.IsFloating="True" />
@@ -173,57 +174,68 @@
                         HorizontalAlignment="Left"
                         Command="{Binding GenerateElements}" />
             </StackPanel>
+            <StackPanel Grid.Row="8">
+                <ComboBox
+                    ItemsSource="{Binding ViewPresetItems}"
+                    SelectedItem="{Binding SelectedViewPreset}"
+                    DisplayMemberPath="Name"
+                    md:HintAssist.Hint="View Preset"
+                    md:HintAssist.IsFloating="True">
+                </ComboBox>
+            </StackPanel>
         </Grid>
 
         <!--ACTIONS-->
         <Grid Grid.Column="2"
               Grid.Row="1">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
 
-            <Button Content="Draw Line"
-                    Command="{Binding DrawLineCommand}"
-                    Width="120"
-                    Height="30"
-                    HorizontalAlignment="Right" />
+                <Button Content="Draw Line"
+                            Command="{Binding DrawLineCommand}"
+                            Width="120"
+                            Height="30"
+                            HorizontalAlignment="Right" />
 
-            <Button Content="Draw Rect"
-                    Command="{Binding DrawRectCommand}"
-                    Width="120"
-                    Height="30"
-                    HorizontalAlignment="Right"
-                    Grid.Row="1" />
+                <Button Content="Draw Rect"
+                            Command="{Binding DrawRectCommand}"
+                            Width="120"
+                            Height="30"
+                            HorizontalAlignment="Right"
+                            Grid.Row="1" />
 
-            <Button Content="Resize"
-                    Command="{Binding ResizeCommand}"
-                    MinWidth="120"
-                    Height="30"
-                    HorizontalAlignment="Right"
-                    Grid.Row="2" />
+                <Button Content="Resize"
+                            Command="{Binding ResizeCommand}"
+                            MinWidth="120"
+                            Height="30"
+                            HorizontalAlignment="Right"
+                            Grid.Row="2" />
 
-            <Button Content="Draw Bezier"
-                    Command="{Binding DrawBezierCommand}"
-                    Width="120"
-                    Height="30"
-                    HorizontalAlignment="Right"
-                    Grid.Row="3" />
+                <Button Content="Draw Bezier"
+                            Command="{Binding DrawBezierCommand}"
+                            Width="120"
+                            Height="30"
+                            HorizontalAlignment="Right"
+                            Grid.Row="3" />
 
-            <Button Content="Delete"
-                    Command="{Binding DeleteCommand}"
-                    Width="120"
-                    Height="30"
-                    HorizontalAlignment="Right"
-                    Grid.Row="4" />
-            <StackPanel Grid.Row="5"
+                <Button Content="Delete"
+                            Command="{Binding DeleteCommand}"
+                            Width="120"
+                            Height="30"
+                            HorizontalAlignment="Right"
+                            Grid.Row="4" />
+                <StackPanel Grid.Row="5"
                         Visibility="{Binding ShowProperties, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <views:PropertiesInfo DataContext="{Binding SelectedItem}" />
-            </StackPanel>
+                    <views:PropertiesInfo DataContext="{Binding SelectedItem}" />
+                </StackPanel>
+            </Grid>
         </Grid>
 
         <!--INFO FOOTER-->
@@ -234,23 +246,31 @@
                 <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="auto" />
             </Grid.ColumnDefinitions>
             <StackPanel Orientation="Horizontal"
                         Margin="2"
                         Grid.Column="1">
+                <TextBlock Text="Transform Offset: " />
+                <TextBlock Text="{Binding TranslateOffset, ElementName=source, Converter={StaticResource PointToStringConverter}}"
+                           HorizontalAlignment="Left"></TextBlock>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal"
+                        Margin="2"
+                        Grid.Column="2">
                 <TextBlock Text="Mouse Location: " />
                 <TextBlock Text="{Binding MousePosition, ElementName=source, Converter={StaticResource PointToStringConverter}}"
                            HorizontalAlignment="Left"></TextBlock>
             </StackPanel>
             <StackPanel Orientation="Horizontal"
-                        Grid.Column="2"
+                        Grid.Column="3"
                         Margin="2">
                 <TextBlock Text="Zoom: " />
                 <TextBlock Text="{Binding Scale, ElementName=source}"
                            HorizontalAlignment="Left"></TextBlock>
             </StackPanel>
             <StackPanel Orientation="Horizontal"
-                        Grid.Column="3"
+                        Grid.Column="4"
                         Margin="2">
                 <TextBlock Text="Bounding Box: " />
                 <TextBlock Text="{Binding ElementName=source, Path=ViewportRect.Location, StringFormat= '\{0\} (left, top)'}"></TextBlock>
@@ -283,7 +303,8 @@
                                      MinScale="{Binding MinScale, Converter={StaticResource StringToFloatConverter},ConverterParameter=double}"
                                      MaxScale="{Binding MaxScale, Converter={StaticResource StringToFloatConverter},ConverterParameter=double}"
                                      AutoPanSpeed="{Binding AutoPanSpeed, Converter={StaticResource StringToFloatConverter}}"
-                                     AutoPanTickRate="{Binding AutoPanTickRate, Converter={StaticResource StringToFloatConverter}}">
+                                     AutoPanTickRate="{Binding AutoPanTickRate, Converter={StaticResource StringToFloatConverter}}"
+                                     TranslateOffset="{Binding TranslateOffset, Mode=TwoWay}">
 
             <richCanvas:RichItemsControl.ContextMenu>
                 <ContextMenu>
@@ -293,6 +314,8 @@
                               Command="{Binding AddTextCommand}" />
                     <MenuItem Header="Paste"
                               Command="{Binding PasteCommand}" />
+                    <MenuItem Header="Add View Preset"
+                              Command="{Binding AddViewPresetCommand}" />
                 </ContextMenu>
             </richCanvas:RichItemsControl.ContextMenu>
 

--- a/RichCanvasDemo/MainWindowViewModel.cs
+++ b/RichCanvasDemo/MainWindowViewModel.cs
@@ -39,6 +39,8 @@ namespace RichCanvasDemo
         private string _minScale = "0.05";
         private bool _showProperties;
         private Drawable _selectedItem;
+        private ViewPresetItem _selectedViewPreset;
+        private Point _translateOffset;
         private ICommand addImageCommand;
         private string scale = "1";
         private bool shouldBringIntoView;
@@ -50,10 +52,12 @@ namespace RichCanvasDemo
         private readonly FileService _fileService;
         private readonly DialogService _dialogService;
         private RelayCommand cancelActionCommand;
+        private RelayCommand addViewPresetCommand;
 
         public ICommand DrawEndedCommand => drawEndedCommand ??= new RelayCommand<RoutedEventArgs>(DrawEnded);
         public ObservableCollection<Drawable> Items { get; }
         public ObservableCollection<Drawable> SelectedItems { get; }
+        public ObservableCollection<ViewPresetItem> ViewPresetItems { get; }
         public ICommand DrawRectCommand => drawRectCommand ??= new RelayCommand(OnDrawCommand);
         public ICommand GenerateElements => generateElementsCommand ??= new RelayCommand(OnGenerateElements);
         public ICommand DrawLineCommand => drawLineCommand ??= new RelayCommand(DrawLine);
@@ -64,6 +68,7 @@ namespace RichCanvasDemo
         public ICommand AddImageCommand => addImageCommand ??= new RelayCommand(AddImage);
         public ICommand CopyCommand => copyCommand ??= new RelayCommand<Drawable>(Copy);
         public RelayCommand PasteCommand => pasteCommand ??= new RelayCommand(Paste, () => _copiedElement != null);
+        public ICommand AddViewPresetCommand => addViewPresetCommand ??= new RelayCommand(AddViewPreset);
 
         public bool EnableGrid
         {
@@ -125,10 +130,25 @@ namespace RichCanvasDemo
 
         public bool IsDragging { get; set; }
 
+        public Point TranslateOffset { get => _translateOffset; set => SetProperty(ref _translateOffset, value); }
+
+        public ViewPresetItem SelectedViewPreset
+        {
+            get => _selectedViewPreset;
+            set
+            {
+                SetProperty(ref _selectedViewPreset, value);
+
+                TranslateOffset = value.Offset;
+                Scale = value.Scale;
+            }
+        }
+
         public MainWindowViewModel()
         {
             Items = new ObservableCollection<Drawable>();
             SelectedItems = new ObservableCollection<Drawable>();
+            ViewPresetItems = new ObservableCollection<ViewPresetItem>();
             SelectedItems.CollectionChanged += SelectedItemsChanged;
             _fileService = new FileService();
             _dialogService = new DialogService();
@@ -307,6 +327,17 @@ namespace RichCanvasDemo
         private void CancelAction()
         {
             DrawingEndedHandled = true;
+        }
+
+        private void AddViewPreset()
+        {
+            ViewPresetItems.Add(
+                new ViewPresetItem
+                {
+                    Name = $"Sample name {this.ViewPresetItems.Count + 1}",
+                    Offset = TranslateOffset,
+                    Scale = Scale
+                });
         }
     }
 }


### PR DESCRIPTION
Hi.

I have been looking at this project for a few days and i have spoted that TranslateOffset is never updated. In this pull request i have added update in function `OnTranslateChanged`.

`private void OnTranslateChanged(object sender, EventArgs e)
{
    TranslateOffset = new Point(TranslateTransform.X, TranslateTransform.Y);
    RaiseScrollingEvent(e);
}`

Reason for this change was saving current pan and zoom level into database, so the user can switch between views presented in eg. ComboBox. 

With this in mind I have also expandend the demo application, which now offers saving current view from the ContextMenu and selecting the saved view from the ComboBox.