### PR TITLE
Add FitToScreen feature

### DIFF
--- a/RichCanvas/Gestures/RichCanvasGestures.cs
+++ b/RichCanvas/Gestures/RichCanvasGestures.cs
@@ -41,6 +41,11 @@ namespace RichCanvas.Gestures
         public static InputGesture Pan { get; set; } = new MouseKeyGesture(new MouseGesture(MouseAction.LeftClick), new KeyGesture(Key.Space));
 
         /// <summary>
+        /// Gets or sets the <see cref="InputGesture"/> used to match the <see cref="RichCanvasCommands.FitToScreen"/>.
+        /// </summary>
+        public static InputGesture FitToScreen { get; set; } = new KeyGesture(Key.Home);
+
+        /// <summary>
         /// Gets or sets the <see cref="ModifierKeys"/> used together with MouseWheel for zooming.
         /// <br/>
         /// Default is <see cref="ModifierKeys.Control"/>.

--- a/RichCanvas/RichCanvas.Fitting.cs
+++ b/RichCanvas/RichCanvas.Fitting.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Windows;
+
+namespace RichCanvas
+{
+    public partial class RichCanvas
+    {
+        private void FitViewToChildren(double marginX, double marginY)
+        {
+            if (ItemsHost.Children.Count == 0)
+            {
+                return;
+            }
+
+            Rect overallBounds = new(0, 0, 0, 0);
+
+            for (int i = 0; i < ItemsHost.Children.Count; i++)
+            {
+                var child = ContainerFromElement(ItemsHost.Children[i]);
+                if (child is RichCanvasContainer container)
+                {
+                    overallBounds.Union(container.BoundingBox);
+                }
+            }
+            overallBounds.Inflate(marginX, marginY);
+
+            FitViewToRect(overallBounds);
+        }
+
+        private void FitViewToRect(Rect newView)
+        {
+            // Size / Size
+            Vector zoomAmounts = new Vector(ActualWidth / newView.Size.Width, ActualHeight / newView.Size.Height);
+            double zoomAmount = Math.Min(zoomAmounts.X, zoomAmounts.Y);
+
+            // Set viewport zoom
+            ViewportZoom = zoomAmount;
+
+            // If the canvas has a ScrollViewer and the scrollbars are visible,
+            // the offset will be off by a tad. Calling this command immediately again will fix it.
+            // We can check if there are scrollbars present by doing:
+            //      if (ExtentHeight != ViewportSize.Height) => VerticalScrollBar present
+            //      if (ExtentWidth != ViewportSize.Width) => HorizontalScrollBar present
+            // You can then try to use SystemParameters.ScrollWidth to try and account for it,
+            // but I could not get the offset perfect. Additionally, if the ScrollBar is ever styled,
+            // then we would have to go find the ScrollBar and get its width. But that opens up another whole
+            // can: we would want to cache it so we don't traverse the tree everytime, but then we need to
+            // add handling for if/when the styling changes.
+
+            // Thus I have decided that being 10 pixels off is not the end of the world, and if anyone is
+            // bothered they can hit the FitToScreen button again.
+
+            // Set viewport location
+            double offsetLeft = (ViewportSize.Width - newView.Size.Width) / 2;
+            double offsetTop = (ViewportSize.Height - newView.Size.Height) / 2;
+            Point topLeft = new Point(newView.TopLeft.X - offsetLeft, newView.TopLeft.Y - offsetTop);
+            ViewportLocation = topLeft;
+        }
+
+        /// <summary>
+        /// Change the viewport location and zoom to fit as many items as possible on screen,
+        /// using a default margin of 0.
+        /// </summary>
+        public void FitToScreen() => FitViewToChildren(0, 0);
+    }
+}
+

--- a/RichCanvas/RichCanvasCommands.cs
+++ b/RichCanvas/RichCanvasCommands.cs
@@ -26,10 +26,19 @@ namespace RichCanvas
             RichCanvasGestures.ZoomOut
         });
 
+        /// <summary>
+        /// Change the viewport location and zoom to fit as many items as possible on screen.
+        /// </summary>
+        public static RoutedUICommand FitToScreen { get; } = new RoutedUICommand("Fit to screen", nameof(FitToScreen), typeof(RichCanvasCommands), new InputGestureCollection
+        {
+           RichCanvasGestures.FitToScreen
+        });
+
         internal static void Register(Type type)
         {
             CommandManager.RegisterClassCommandBinding(type, new CommandBinding(ZoomIn, OnZoomIn));
             CommandManager.RegisterClassCommandBinding(type, new CommandBinding(ZoomOut, OnZoomOut));
+            CommandManager.RegisterClassCommandBinding(type, new CommandBinding(FitToScreen, OnFitToScreen));
         }
 
         private static void OnZoomOut(object sender, ExecutedRoutedEventArgs e)
@@ -45,6 +54,14 @@ namespace RichCanvas
             if (sender is RichCanvas richItemsControl)
             {
                 richItemsControl.ZoomIn();
+            }
+        }
+
+        private static void OnFitToScreen(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (sender is RichCanvas richItemsControl)
+            {
+                richItemsControl.FitToScreen();
             }
         }
     }


### PR DESCRIPTION
## New Feature: FitToScreen ##
### Description ###
Add 'Bring into view feature' from the roadmap. This will fit the Viewport to the center point of all items, fitting all items in screen if the `MinZoom` and `MaxZoom` allow it, otherwise it will place the Viewport in the center of items at max/min zoom.

### Changes ###
- Added FitToScreen method. 
- Added Gesture/Command for the FitToScreen feature. Default is `Key.Home`

### Testing ###
- I Tested this using the existing testing app. All of the following passed when I manually tested them.
  - To test this, add a bunch of shapes onto the canvas using existing the controls. Then press the `Home` key.
  - Test with multiple items close together => Viewport respects `MinZoom`
  - Test with multiple items very far apart => Viewport respects `MaxZoom`
  - Test with no items => Does nothing. *This could be changed to just set viewport location to (0,0) if desired. See the `ItemsHost.Children.Count` check*
  - Test with items off screen => Viewport fits those items to screen
  - Test with a large amount of objects => No performance impact

### Notes ###
- I am unfamiliar with the testing suite and was unable to figure out exactly how to add a new automation test.
- Since the `ViewportZoom` property already coerces the zoom value, I did not add checks on whether the new zoom is within the set `MinZoom` and `MaxZoom` values. If that coercing function is removed, this will need to be updated.
- The FitToScreen method includes optional marginX and marginY parameters, this can be used to add a margin when fitting the screen. This can be made a DependencyProperty if desired, but as of now it defaults to 0.
- I added this as a seperate partial class file as the functionality did not fit the existing Zooming partial class file, since the function does both zooming and panning. Addtionally, the other roadmap item for bringing a container into view would most likely want to be grouped with this one.

### Potential Issues ###
- This feature is a little wonky when scroll bars are present. To see this, move an item outside of the Viewport, then hit the `Home` key. The screen will appear to fit correctly. Hit the `Home` key again. The viewport will adjust an additional time. 
  - This is due to the visible scrollbars affecting the viewport size. When the first fit is made, the viewport is `ViewportSize - ScrollBarWidth`. After the first fit, the scrollbars are no longer visible and the viewport has actually increased by the width of the scrollbars.
  - I added a comment in the code describing this, but decided it was not a major issue as the first FItToScreen is close enough.
  - The comment for reference:
  ```
              // If the canvas has a ScrollViewer and the scrollbars are visible,
            // the offset will be off by a tad. Calling this command immediately again will fix it.
            // We can check if there are scrollbars present by doing:
            //      if (ExtentHeight != ViewportSize.Height) => VerticalScrollBar present
            //      if (ExtentWidth != ViewportSize.Width) => HorizontalScrollBar present
            // You can then try to use SystemParameters.ScrollWidth to try and account for it,
            // but I could not get the offset perfect. Additionally, if the ScrollBar is ever styled,
            // then we would have to go find the ScrollBar and get its width. But that opens up another whole
            // can: we would want to cache it so we don't traverse the tree everytime, but then we need to
            // add handling for if/when the styling changes.

            // Thus I have decided that being 10 pixels off is not the end of the world, and if anyone is
            // bothered they can hit the FitToScreen button again.
```
 
